### PR TITLE
Use action_status not job.status

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,11 +50,11 @@ runs:
     - if: ${{ always() && inputs.slack-webhook }}
       uses: rtCamp/action-slack-notify@v2
       env:
-        SLACK_COLOR: ${{ job.status }}
+        SLACK_COLOR: ${{ github.action_status }}
         SLACK_ICON: https://github.com/freckle-automation.png?size=48
         SLACK_USERNAME: GitHub Actions
         SLACK_TITLE: ${{ github.repository }} deployment
-        SLACK_MESSAGE: ${{ job.status }}
+        SLACK_MESSAGE: ${{ github.action_status }}
         SLACK_FOOTER: ""
         SLACK_WEBHOOK: ${{ inputs.slack-webhook }}
         MSG_MINIMAL: actions url,commit


### PR DESCRIPTION
We've been getting "success" no matter what, it appears that there is a
different syntax in a composite action.

https://docs.github.com/en/actions/learn-github-actions/expressions#example-for-composite-action-step
