### PR TITLE
Fixes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,8 @@ runs:
         version: ${{ inputs.platform-setup-version }}
         token: ${{ inputs.platform-setup-token }}
 
-    - shell: bash
+    - id: deploy
+      shell: bash
       run: |
         cd '${{ inputs.app-directory }}'
         options=()
@@ -47,6 +48,10 @@ runs:
         platform --environment '${{ inputs.environment }}' "${options[@]}" \
           deploy --tag '${{ github.sha }}' --no-confirm
 
+        printf '::set-output name=image::%s:%s\n' \
+          "$(platform "${options[@]}" query settings.EcrRepository)" \
+          '${{ github.sha }}'
+
     - if: ${{ always() && inputs.slack-webhook }}
       uses: rtCamp/action-slack-notify@v2
       env:
@@ -55,6 +60,6 @@ runs:
         SLACK_USERNAME: GitHub Actions
         SLACK_TITLE: ${{ github.repository }} deployment
         SLACK_MESSAGE: ${{ github.action_status }}
-        SLACK_FOOTER: ""
+        SLACK_FOOTER: ${{ steps.deploy.outputs.image }}
         SLACK_WEBHOOK: ${{ inputs.slack-webhook }}
         MSG_MINIMAL: actions url,commit

--- a/action.yml
+++ b/action.yml
@@ -53,13 +53,23 @@ runs:
           '${{ github.sha }}'
 
     - if: ${{ always() && inputs.slack-webhook }}
+      id: prep
+      shell: bash
+      run: |
+        # action_status has been coming out as "Failure", not "failure" as the
+        # docs indicate. To use it as a Slack color, it needs to be
+        # lower-case, so we'll fix that here.
+        status=${{ github.action_status }}
+        printf '::set-output name=status::%s\n' "${status,,}"
+
+    - if: ${{ always() && inputs.slack-webhook }}
       uses: rtCamp/action-slack-notify@v2
       env:
-        SLACK_COLOR: ${{ github.action_status }}
+        SLACK_COLOR: ${{ steps.prep.outputs.status }}
         SLACK_ICON: https://github.com/freckle-automation.png?size=48
         SLACK_USERNAME: GitHub Actions
         SLACK_TITLE: ${{ github.repository }} deployment
-        SLACK_MESSAGE: ${{ github.action_status }}
+        SLACK_MESSAGE: ${{ steps.prep.outputs.status }}
         SLACK_FOOTER: ${{ steps.deploy.outputs.image }}
         SLACK_WEBHOOK: ${{ inputs.slack-webhook }}
         MSG_MINIMAL: actions url,commit


### PR DESCRIPTION
- Include the deployed image in the Slack

  Example:

  ![](https://files.pbrisbin.com/screenshots/screenshot.2137343.png)

- Fix using status as a Slack color

  The documentation indicates that `job.status` and `action_status` both print
  "success" or "failure". However, we've been seeing it capitalized:

  ![](https://files.pbrisbin.com/screenshots/screenshot.2137518.png)

  By lower-casing it ourselves, this should keep colors working.
