### PR TITLE
Fail on empty Slack webhook URL

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,9 +19,8 @@ inputs:
     description: Environment to deploy (required)
     required: true
   slack-webhook:
-    description: Slack Webhook URL, will not notify if empty
-    required: true
-    default: ""
+    description: Slack Webhook URL with which to notify, if desired
+    default: "unused"
 outputs: {}
 runs:
   using: composite
@@ -56,7 +55,7 @@ runs:
               sed 's/,$//; s/,/, /g'
         } >>"$GITHUB_OUTPUT"
 
-    - if: ${{ always() && inputs.slack-webhook }}
+    - if: ${{ always() && inputs.slack-webhook != 'unused'}}
       id: prep
       shell: bash
       run: |
@@ -66,7 +65,7 @@ runs:
         status=${{ github.action_status }}
         printf 'status=%s\n' "${status,,}" >>"$GITHUB_OUTPUT"
 
-    - if: ${{ always() && inputs.slack-webhook }}
+    - if: ${{ always() && inputs.slack-webhook != 'unused' }}
       uses: rtCamp/action-slack-notify@v2
       env:
         SLACK_COLOR: ${{ steps.prep.outputs.status }}


### PR DESCRIPTION
Currently, if the `slack-webhook` input is a secret that does not exist in the repository, the notify steps will be skipped. Since this is usually a sign of misconfiguration, the action should produce a failure instead. However, since the inputs in this scenario look identical to how a user would opt to not have the action notify, the input is changed to optional and the notify steps are instead skipped when matching on a default input value, rather than an empty value.

For example, there is no `SLACK_WEBHOOK_URL` in the repository secrets, `secrets.SLACK_WEBHOOK_URL` is an empty value that replaces the default value of the `slack-webhook` input. `rtCamp/action-slack-notify` will then [throw an error][0] attempting to use this as a webhook.

[0]: https://github.com/rtCamp/action-slack-notify/blob/master/main.go#L60