### PR TITLE
CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: main
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.2.0
+      - uses: ./action.yml
+        with:
+          dry-run: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.2.0
-      - uses: ./action.yml
+      - uses: ./
         with:
           dry-run: true

--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ runs:
         if platform --color always version &>/dev/null; then
           options+=( --color always )
         fi
-        
+
         if '${{ inputs.dry-run }}'; then
           echo "Dry run: Skipping deploy"
           echo "stackNames=" >>"$GITHUB_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -21,11 +21,16 @@ inputs:
   slack-webhook:
     description: Slack Webhook URL with which to notify, if desired
     default: "unused"
+  dry-run:
+    description: Skip deploying the App
+    require: true
+    default: false
 outputs: {}
 runs:
   using: composite
   steps:
-    - uses: freckle/setup-platform-action@v6
+    - if: ${{ always() && !inputs.dry-run }}
+      uses: freckle/setup-platform-action@v6
       with:
         version: ${{ inputs.platform-setup-version }}
         token: ${{ inputs.platform-setup-token }}
@@ -42,6 +47,12 @@ runs:
 
         if platform --color always version &>/dev/null; then
           options+=( --color always )
+        fi
+        
+        if '${{ inputs.dry-run }}'; then
+          echo "Dry run: Skipping deploy"
+          echo "stackNames=" >>"$GITHUB_OUTPUT"
+          exit 0
         fi
 
         platform --environment '${{ inputs.environment }}' "${options[@]}" \


### PR DESCRIPTION
Validate the composite action YAML by using a `dry-run` input to bypass deployment (which will fail in this repo and is hard to setup). In the future this CI workflow can be expanded to check step outputs, such as to validate if a Slack notification went out as expected (see #8)